### PR TITLE
Added Available as a state to the bigip_device_facts members

### DIFF
--- a/library/bigip_device_facts.py
+++ b/library/bigip_device_facts.py
@@ -9405,6 +9405,8 @@ class LtmPoolsParameters(BaseParameters):
                 member['state'] = 'forced_offline'
             elif state in ['down'] and session in ['monitor-enabled']:
                 member['state'] = 'offline'
+            elif state in ['up'] and session in ['monitor-enabled']:
+                member['state'] = 'online'
             else:
                 member['state'] = 'disabled'
             self._remove_internal_keywords(member)

--- a/library/bigip_device_facts.py
+++ b/library/bigip_device_facts.py
@@ -9406,7 +9406,7 @@ class LtmPoolsParameters(BaseParameters):
             elif state in ['down'] and session in ['monitor-enabled']:
                 member['state'] = 'offline'
             elif state in ['up'] and session in ['monitor-enabled']:
-                member['state'] = 'online'
+                member['state'] = 'available'
             else:
                 member['state'] = 'disabled'
             self._remove_internal_keywords(member)


### PR DESCRIPTION
If you have monitoring on a pool and have pool members which are operational, they show as disabled currently. This will take their 'up' state and report 'available' back to Ansible. This is the same description used for pool statuses that show green.